### PR TITLE
[CHORE] ruby v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.4-alpine
 
 LABEL com.github.actions.name="Rubocop checks"
 LABEL com.github.actions.description="Lint your Ruby code in parallel to your builds"


### PR DESCRIPTION
The cobwebs on this action have grown thick enough to that they're choking the works lol
```
Building native extensions. This could take a while...
ERROR:  Error installing rubocop:
	The last version of public_suffix (>= 2.0.2, < 8.0) to support your Ruby & RubyGems was 5.1.1. Try installing it with `gem install public_suffix -v 5.1.1` and then running the current command again
	public_suffix requires Ruby version >= 3.2. The current ruby version is 2.7.8.225.
```